### PR TITLE
Remove unsupported runtime config

### DIFF
--- a/ACViewer/App.config
+++ b/ACViewer/App.config
@@ -1,6 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
-    </startup>
 </configuration>


### PR DESCRIPTION
## Summary
- remove `supportedRuntime` from App.config since it is not valid and the project overall already target .net 8