### PR TITLE
Update .gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,12 @@
 .vs/
 bin/
 obj/
+**/build/
+**/bin/
+**/obj/
+Build/
+Debug/
+Release/
 *.user
+ACViewer.json
+*.log


### PR DESCRIPTION
## Summary
- ignore `ACViewer.json` configuration files
- ignore `*.log` output
- ignore temporary build folders created during compilation