### PR TITLE
Replace PostBuildEvent with Copy target

### DIFF
--- a/ACViewer/ACViewer.csproj
+++ b/ACViewer/ACViewer.csproj
@@ -100,33 +100,27 @@
     </None>
   </ItemGroup>
 
-	<PropertyGroup>
-		<PostBuildEvent>
-			robocopy $(SolutionDir)docs $(TargetDir)docs /S /E /COPY:DAT /MIR /NP /TEE /V
-
-			if %25ERRORLEVEL%25 EQU 16 echo ***FATAL ERROR*** &amp; goto end
-			if %25ERRORLEVEL%25 EQU 15 echo OKCOPY + FAIL + MISMATCHES + XTRA &amp; goto end
-			if %25ERRORLEVEL%25 EQU 14 echo FAIL + MISMATCHES + XTRA &amp; goto end
-			if %25ERRORLEVEL%25 EQU 13 echo OKCOPY + FAIL + MISMATCHES &amp; goto end
-			if %25ERRORLEVEL%25 EQU 12 echo FAIL + MISMATCHES&amp; goto end
-			if %25ERRORLEVEL%25 EQU 11 echo OKCOPY + FAIL + XTRA &amp; goto end
-			if %25ERRORLEVEL%25 EQU 10 echo FAIL + XTRA &amp; goto end
-			if %25ERRORLEVEL%25 EQU 9 echo OKCOPY + FAIL &amp; goto end
-			if %25ERRORLEVEL%25 EQU 8 echo FAIL &amp; goto end
-			if %25ERRORLEVEL%25 EQU 7 echo OKCOPY + MISMATCHES + XTRA &amp; goto end
-			if %25ERRORLEVEL%25 EQU 6 echo MISMATCHES + XTRA &amp; goto end
-			if %25ERRORLEVEL%25 EQU 5 echo OKCOPY + MISMATCHES &amp; goto end
-			if %25ERRORLEVEL%25 EQU 4 echo MISMATCHES &amp; goto end
-			if %25ERRORLEVEL%25 EQU 3 echo OKCOPY + XTRA &amp; goto end
-			if %25ERRORLEVEL%25 EQU 2 echo XTRA &amp; goto end
-			if %25ERRORLEVEL%25 EQU 1 echo OKCOPY &amp; goto end
-			if %25ERRORLEVEL%25 EQU 0 echo No Change &amp; goto end
-			:end
-			exit 0
-		</PostBuildEvent>
-	</PropertyGroup>
 
 	<PropertyGroup>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
 	</PropertyGroup>	
+  <Target Name="CopyDocs" AfterTargets="Build">
+    <PropertyGroup>
+      <DocsSource>$(SolutionDir)docs</DocsSource>
+      <DocsDestination>$(TargetDir)docs</DocsDestination>
+    </PropertyGroup>
+    <OnError ExecuteTargets="CopyDocsFailed" />
+    <Error Condition="!Exists('$(DocsSource)')" Text="Source docs directory not found: $(DocsSource)" />
+    <Error Condition="!Exists('$(TargetDir)')" Text="Target directory not found: $(TargetDir)" />
+    <MakeDir Directories="$(DocsDestination)" Condition="!Exists('$(DocsDestination)')" />
+    <ItemGroup>
+      <DocFiles Include="$(DocsSource)\**\*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(DocFiles)" DestinationFiles="@(DocFiles->'$(DocsDestination)\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+    <Message Text="Documentation successfully copied to $(DocsDestination)." Importance="high" />
+  </Target>
+
+  <Target Name="CopyDocsFailed">
+    <Message Text="Documentation copy task failed. Ensure the 'docs' directory exists." Importance="high" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
- remove old PostBuildEvent that used robocopy
- add MSBuild `CopyDocs` target that mirrors `docs` folder
- fail with an error if the docs directory or target directory is missing
- display a user message when the copy task fails
- show a success message when documentation is copied